### PR TITLE
SalesForce exception with empty error and body in response (no context)

### DIFF
--- a/index.js
+++ b/index.js
@@ -990,7 +990,14 @@ var apiRequest = function(opts, oauth, sobject, callback) {
   }
   
   return request(opts, function(err, res, body) {
-    if(!err && res.statusCode == 200 || res.statusCode == 201 || res.statusCode == 202 || res.statusCode == 204) {
+    if(!err && !body) {
+      if(res.headers && res.headers.error) {
+        err = new Error(res.headers.error);
+      } else {
+        err = new Error('Server returned '+res.statusCode+' with an empty response');
+      }
+      callback(err, null);
+    } else if(!err && res.statusCode == 200 || res.statusCode == 201 || res.statusCode == 202 || res.statusCode == 204) {
       if(body) body = JSON.parse(body);
       // attach the id back to the sobject on insert
       if(sobject && body && body.id && !sobject.Id && !sobject.id && !sobject.ID) sobject.Id = body.id;


### PR DESCRIPTION
In production, Node was catching an 'uncaughtException' where the body coming back from request() was undefined. Attempting to index this element was throwing the exception. This was occurring during a request to SalesForce which received a 500 response with an error tucked into the header.

I provided a case where there is no error or body. An attempt is made to find the error in the header.
