### PR TITLE
Update query() to be either in streaming mode or non-streaming mode

### DIFF
--- a/lib/querystream.js
+++ b/lib/querystream.js
@@ -19,6 +19,10 @@ QueryStream.prototype.end = function(string) {
   this.emit('end', string);
 } 
 
+QueryStream.prototype.error = function(err) {
+  this.emit('error', err);
+}
+
 QueryStream.prototype.isStreaming = function() {
   if(this.listeners('data').length) {
     return true;


### PR DESCRIPTION
These changes were necessary to enable streaming mode to pull back large amounts of data (>90000 contacts) via calls to getNextUrl.  query() is now either in streaming mode or non-streaming mode.  When in streaming mode, no callback is used and instead stream events are emitted.  When in non-streaming mode, callback is used for control flow.
