### PR TITLE
Do not convert already-string bodies to string

### DIFF
--- a/index.js
+++ b/index.js
@@ -840,7 +840,7 @@ Connection.prototype.apexRest = function(restRequest, oauth, callback) {
   opts = { uri: uri, method: restRequest.method}
   
   if(restRequest.body!=null) {
-    opts.body = JSON.stringify(restRequest.body);
+    opts.body = typeof restRequest.body === 'string' ? restRequest.body : JSON.stringify(restRequest.body);
   }
 
   if(restRequest.urlParams!=null) {


### PR DESCRIPTION
...doing so adds extra double-quotes around original string.

Running mocha the tests pass (although i haven't dug into them).

I was unable to POST with Connection.prototype.apexRest to the <pre>https://instance.salesforce.com/services/apexrest/v.9/members</pre> the required parameters in the format it was expected because of the double-quote issue.
