### PR TITLE
Support backpressure (albeit still old-style)

### DIFF
--- a/lib/querystream.js
+++ b/lib/querystream.js
@@ -23,6 +23,16 @@ QueryStream.prototype.error = function(err) {
   this.emit('error', err);
 }
 
+QueryStream.prototype.pause = function () {
+  this.writable = false;
+  this.emit('pause');
+}
+
+QueryStream.prototype.resume = function () {
+  this.writable = true;
+  this.emit('resume');
+}
+
 QueryStream.prototype.isStreaming = function() {
   if(this.listeners('data').length) {
     return true;


### PR DESCRIPTION
This pull request is needed for streams that need to provide backpressure via the old-style pause/resume interface.

Without this PR, pulling in millions of salesforce records will cause the use of streams to blow up in memory and often crash out of memory usage, which was a disaster for us. This keeps the memory nice and steady.
