### PR TITLE
Fix broken apexRest endpoint and add apexRest test.

### DIFF
--- a/index.js
+++ b/index.js
@@ -519,6 +519,7 @@ Connection.prototype.getUrl = function(data, callback) {
 Connection.prototype.apexRest = function(data, callback) {
   // need to specify resource
   var opts = this._getOpts(data, callback);
+  opts.uri = opts.oauth.instance_url + '/services/apexrest/' + data.uri;
   opts.method = opts.method || 'GET';
   if(opts.urlParams) {
     opts.qs = opts.urlParams;

--- a/test/api-mock-crud.js
+++ b/test/api-mock-crud.js
@@ -94,6 +94,18 @@ describe('api-mock-crud', function() {
 
   });
 
+  describe('#apexRest', function() {
+
+    it('should create a proper request for a custom Apex REST endpoint', function(done) {
+      org.apexRest({ uri: 'sample', oauth: oauth }, function(err, res) {
+        api.getLastRequest().url.should.equal('/services/apexrest/sample');
+        api.getLastRequest().method.should.equal('GET');
+        done();
+      });
+    });
+
+  });
+
   // reset the lastRequest
   afterEach(function() {
     api.reset();


### PR DESCRIPTION
apexRest endpoint was broken in v0.7.0 when the api was refactored to use _getOpts.
