### PR TITLE
Fix bug preventing separate subscription callbacks on multiple stream subscriptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -549,7 +549,7 @@ Connection.prototype.stream = function(data) {
   var opts = this._getOpts(data);
   var client, endpoint;
 
-  str = new FDCStream();
+  var str = new FDCStream();
 
   endpoint = opts.oauth.instance_url + '/cometd/' + that.apiVersion.substring(1);
 


### PR DESCRIPTION
Lack of `var` token is letting what should be a local variable treated as a global so that subsequent subscriptions handlers clobber the initial ones.
Fixes #53 
