### PR TITLE
Bumped API version to v30.0 so can access newer objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ var AUTH_ENDPOINT      = 'https://login.salesforce.com/services/oauth2/authorize
 var TEST_AUTH_ENDPOINT = 'https://test.salesforce.com/services/oauth2/authorize';
 var LOGIN_URI          = 'https://login.salesforce.com/services/oauth2/token';
 var TEST_LOGIN_URI     = 'https://test.salesforce.com/services/oauth2/token';
-var API_VERSIONS       = ['v20.0', 'v21.0', 'v22.0', 'v23.0', 'v24.0', 'v25.0', 'v26.0', 'v27.0', 'v28.0', 'v29.0'];
+var API_VERSIONS       = ['v20.0', 'v21.0', 'v22.0', 'v23.0', 'v24.0', 'v25.0', 'v26.0', 'v27.0', 'v28.0', 'v29.0', 'v30.0'];
 var ENVS               = ['sandbox', 'production'];
 var MODES              = ['multi', 'single'];
 


### PR DESCRIPTION
I'm using the nforce-tooling project and I need access to some of the newer objects in the tooling API which are limited to API 30 but as nforce is limiting the version to 29 I can't use them without updating the version here. 
