### PR TITLE
Add custom headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -696,6 +696,7 @@ Connection.prototype._apiRequest = function(opts, callback) {
    * - method
    * - body
    * - qs
+   * - headers
    */
 
   var self = this;
@@ -739,6 +740,12 @@ Connection.prototype._apiRequest = function(opts, callback) {
     ropts.headers['content-type'] = 'multipart/form-data';
   } else {
     ropts.headers['content-type'] = 'application/json';
+  }
+
+  if(opts.headers) {
+    for(var item in opts.headers) {
+      ropts.headers[item] = opts.headers[item];
+    }
   }
 
   // set body

--- a/test/api-mock-crud.js
+++ b/test/api-mock-crud.js
@@ -24,19 +24,25 @@ describe('api-mock-crud', function() {
         Name: 'Test Account',
         Test_Field__c: 'blah'
       });
-      org.insert({ sobject: obj, oauth: oauth }, function(err, res) {
+      var hs = {
+        'sforce-auto-assign': '1'
+      };
+      org.insert({ sobject: obj, oauth: oauth, headers: hs }, function(err, res) {
         if(err) throw err;
         var body = JSON.parse(api.getLastRequest().body);
         should.exist(body.name);
         should.exist(body.test_field__c);
         api.getLastRequest().url.should.equal('/services/data/v27.0/sobjects/account');
         api.getLastRequest().method.should.equal('POST');
+        var hKey = Object.keys(hs)[0];
+        should.exist(api.getLastRequest().headers[hKey]);
+        api.getLastRequest().headers[hKey].should.equal(hs[hKey]);
         done();
       });
     });
 
   });
-  
+
   describe('#update', function() {
 
     it('should create a proper request on update', function(done) {
@@ -116,4 +122,4 @@ describe('api-mock-crud', function() {
     api.stop(done);
   });
 
-}); 
+});


### PR DESCRIPTION
This PR allows to specify custom SF headers such as `Sforce-Auto-Assign`, `Sforce-Call-Options`, etc as per [SF docs](https://www.salesforce.com/us/developer/docs/api_rest/Content/headers.htm)
