### PR TITLE
apexRest: Allow data.uri to start with/w/o a /

### DIFF
--- a/index.js
+++ b/index.js
@@ -719,7 +719,9 @@ Connection.prototype.apexRest = function(data, callback) {
   var opts = this._getOpts(data, callback, {
     singleProp: 'uri'
   });
-  opts.uri = opts.oauth.instance_url + '/services/apexrest/' + data.uri;
+  opts.uri = opts.oauth.instance_url + '/services/apexrest/' 
+    // Allow for data.uri to start with or without a /
+    + ((data.uri.substring(0,1)==='/') ? data.uri.substring(1) : data.uri);
   opts.method = opts.method || 'GET';
   if(opts.urlParams) {
     opts.qs = opts.urlParams;


### PR DESCRIPTION
A common source of frustration for me was not knowing whether the uri to pass in to apexRest should start with a / or not. This change allows it to start with or without a /.