### PR TITLE
Pass headers up for API Limit Throttling

### DIFF
--- a/index.js
+++ b/index.js
@@ -998,6 +998,7 @@ Connection.prototype._apiRequest = function(opts, callback) {
             sobject._fields.id = body.id;
           }
         }
+        body.headers = res && res.headers;
         return resolver.resolve(body);
       }
 


### PR DESCRIPTION
I don't want to use all of our customers salesforce API Requests. If I knew how close our customers were to hitting their limits, I could throttle my requests.

The salesforce api includes an header in the HTTP Response like:
`api-usage=27067/32000`

With this one line change plugins could leverage this data and throttle requests.  Here's a simple method I put together for extracting used / total.
I think an even better solution would be to report back these numbers already decoded... but didn't want to rip up your codebase too much.

```
exports.getApiCallsUsed = function(body) {
    var obj = {};
    var usageString = _lo.get(body, "headers.sforce-limit-info");
    if(usageString) {
        try {
            usageString = usageString.split("=")[1];
            obj.used = usageString.split("/")[0];
            obj.total = usageString.split("/")[1];
            obj.remaining = obj.total - obj.used;
            obj.percentUsed = Math.round( (obj.used * 100) / obj.total);
            obj.percentRemaining = 100 - obj.percentUsed;
        }
        catch(err) {
            // do nothing wrong format
        }
    }
    return obj;
};
```
