### PR TITLE
platform events [stuff__e] support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ nforce :: node.js salesforce REST API wrapper
 
 [![Build Status](https://secure.travis-ci.org/kevinohara80/nforce.png)](http://travis-ci.org/kevinohara80/nforce)
 [![npm version](https://badge.fury.io/js/nforce.svg)](https://badge.fury.io/js/nforce)
- 
+
 
 
 **nforce** is node.js a REST API wrapper for force.com, database.com,
@@ -1104,9 +1104,10 @@ events:
 
 opts:
 
-* `topic`: (String:Required) An string value for the streaming topic
+* `topic`: (String:Required) An string value for the streaming topic or Platform Event object (ex: event_name__e)
 * `isSystem`: (Boolean:Optional) Specify `true` if the topic to be
 streamed is a SystemTopic
+* `isEvent`: (Boolean:Optional) Specify `true` if you want to subscribe to a Platform Event instead of a push topic.
 
 Creates and returns a streaming api subscription object. See the
 *Streaming Subscription Methods* section for more details on the

--- a/examples/platform-event.js
+++ b/examples/platform-event.js
@@ -1,0 +1,32 @@
+var nforce = require('../');
+
+var org = nforce.createConnection({
+  clientId: '3MVG9SemV5D80oBea2IeBN0xcz_C0GLWbts0E6VRV293FNa4eILStgASMWudupPnTZvB7tCHSsEZL5RV_FcDo',
+  clientSecret: '5422396158889181410',
+  redirectUri: 'http://localhost:3000/oauth/_callback',
+  environment: 'production'
+});
+
+
+org.authenticate({ username: process.env.SFUSER, password: process.env.SFPASS}, function(err, oauth){
+
+  if(err) return console.log(err);
+
+  console.log('connecting to event');
+  var str = org.stream({ topic: 'Test_event__e', oauth: oauth, isEvent:true, apiVersion: 'v39.0' });
+
+  str.on('connect', function(){
+    console.log('connected to event source');
+  });
+
+  str.on('error', function(error) {
+    console.log('error: ' + error);
+  });
+
+  str.on('data', function(data) {
+    console.log(data);
+    str.cancel();
+    str.client.disconnect();
+  });
+
+});

--- a/lib/fdcstream.js
+++ b/lib/fdcstream.js
@@ -11,7 +11,9 @@ function Subscription(opts, client) {
 
   if(opts.isSystem) {
     this._topic = '/systemTopic/' + opts.topic;
-  } else {
+  } else if (opts.isEvent){
+    this._topic = '/event/' + opts.topic;
+  }else {
     this._topic = '/topic/' + opts.topic;
   }
 


### PR DESCRIPTION
Kevin, I wasn't sure which direction to take this...there's so much shared with streaming that I wanted to reuse as much as possible.  So I copied the "put a flag on it" like you had for system topics, but just modified it for events, which move from Beta to GA in summer17.

Let me know if this makes sense, or if you'd rather a completely different function for platform events.