### PR TITLE
fix misspelled method name (setAttachement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ value that you are trying to match on.
 
 Returns the attachment object if set
 
-### setAttachement(fileName, body)
+### setAttachment(fileName, body)
 
 Sets the fileName (String) and body (buffer) for an attachment
 


### PR DESCRIPTION
In the README the heading for the `setAttachment` method is incorrectly spelled `setAttachement`, noticed this when it didn't come up in a cmd + f search.