### PR TITLE
feat: remove bluebird in favor of native promises

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "0.12"
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -464,8 +464,7 @@ org.getUrl(url, myCallback);
 
 ### Promises
 
-**nforce** also supports promises based on
-[Bluebird](https://github.com/petkaantonov/bluebird). When no
+**nforce** also supports promises based on native promises. When no
 callback is supplied to an asynchronous method (like an api call),
 a promise will be returned. This makes control-flow very simple.
 
@@ -474,7 +473,7 @@ org.authenticate({ username: un, password: pw }).then(function(){
   return org.getResources();
 }).then(function(resources) {
   console.log('resources: ' + resources);
-}).error(function(err) {
+}).catch(function(err) {
   console.error('there was a problem');
 });
 ```

--- a/examples/crud-promises.js
+++ b/examples/crud-promises.js
@@ -38,13 +38,9 @@ org.authenticate({ username: sfuser, password: sfpass }).then(function(oauth){
   console.log('deleting lead');
   return org.delete({ sobject: ld });
 
-}).error(function(err) {
+}).catch(function(err) {
 
   console.error('crud failed');
   console.error(err);
-
-}).finally(function() {
-
-  console.log('exiting');
 
 });

--- a/lib/promises.js
+++ b/lib/promises.js
@@ -1,38 +1,25 @@
-var P = require('bluebird');
-var _ = require('lodash');
-
-// add back in deferreds
-var deferred = function() {
-  var resolve, reject;
-  var promise = new P(function() {
-    resolve = arguments[0];
-    reject = arguments[1];
-  });
-  return {
-    resolve: resolve,
-    reject: reject,
-    promise: promise
-  };
-};
+const _ = require('lodash');
 
 var createResolver = function(callback) {
-  var defer;
-  if(!callback || !_.isFunction(callback)) {
-    defer = deferred();
+  if (callback && _.isFunction(callback)) {
+    return {
+      resolve: function (data) { callback(null, data); },
+      reject: function (err) { callback(err); },
+    };
   }
+
+  var resolvePromise;
+  var rejectPromise;
+  var promise = new Promise(function (resolve, reject) {
+    resolvePromise = resolve;
+    rejectPromise  = reject;
+  });
+
   return {
-    resolve: function(data) {
-      if(callback) callback(null, data);
-      else if(defer) defer.resolve(data);
-    },
-    reject: function(err) {
-      if(callback) callback(err);
-      else if(defer) defer.reject(err);
-    },
-    promise: (defer) ? defer.promise : undefined
+    resolve: resolvePromise,
+    reject: rejectPromise,
+    promise: promise,
   };
 };
 
-module.exports.Promise        = P;
-module.exports.deferred       = deferred;
 module.exports.createResolver = createResolver;

--- a/package-lock.json
+++ b/package-lock.json
@@ -202,11 +202,6 @@
       "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
       "dev": true
     },
-    "bluebird": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
-    },
     "body-parser": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "main": "index.js",
   "dependencies": {
-    "bluebird": "^2.3.11",
     "faye": "1.2.3",
     "lodash": "^3.10.1",
     "mime": "1.4.1",
@@ -40,7 +39,7 @@
   },
   "optionalDependencies": {},
   "engines": {
-    "node": "*"
+    "node": ">= 0.12"
   },
   "bugs": {
     "url": "http://github.com/kevinohara80/nforce/issues"

--- a/test/query.js
+++ b/test/query.js
@@ -39,7 +39,7 @@ describe('query', function(){
         api.getLastRequest().url.should.equal(expected);
         api.getLastRequest().headers.should.have.property('authorization', 'Bearer ' + oauth.access_token);
         done();
-      }).error(function(err){
+      }).catch(function(err){
         should.not.exist(err);
         done();
       });
@@ -56,7 +56,7 @@ describe('query', function(){
       orgSingle.query({ query: testQuery }).then(function(res) {
         api.getLastRequest().url.should.equal(expected);
         done();
-      }).error(function(err){
+      }).catch(function(err){
         should.not.exist(err);
         done();
       });
@@ -88,7 +88,7 @@ describe('query', function(){
         api.getLastRequest().url.should.equal(expected);
         verifyAccessToken();
         done();
-      }).error(function(err){
+      }).catch(function(err){
         should.not.exist(err);
         done();
       });
@@ -107,7 +107,7 @@ describe('query', function(){
         api.getLastRequest().url.should.equal(expected);
         verifyAccessToken();
         done();
-      }).error(function(err){
+      }).catch(function(err){
         should.not.exist(err);
         done();
       });


### PR DESCRIPTION
You probably don't want this but you have the option. Resolves #161.

Some breaking changes: `.error()` becomes `.catch()` and `.finally()` no longer exists for those who were relying on it.

And it also now requires `node >= 0.12` since that's when native promises were introduced.