### PR TITLE
add support for Change Data Capture events

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,6 +877,7 @@ opts:
 * `topic`: (String:Required) A string value for the streaming topic or Platform Event object (ex: event_name__e).
 * `isSystem`: (Boolean:Optional) Specify `true` if the topic to be streamed is a SystemTopic.
 * `isEvent`: (Boolean:Optional) Specify `true` if you want to subscribe to a Platform Event instead of a push topic.
+* `isChangeDataCapture`: (Boolean:Optional) Specify `true` if you want to subscribe to a Change Data Capture Event instead of a push topic.
 
 Creates and returns a streaming api subscription object. See the *Streaming Subscription Methods* section for more details on the subscription object.
 

--- a/lib/fdcstream.js
+++ b/lib/fdcstream.js
@@ -13,7 +13,9 @@ function Subscription(opts, client) {
     this._topic = '/systemTopic/' + opts.topic;
   } else if (opts.isEvent){
     this._topic = '/event/' + opts.topic;
-  }else {
+  } else if(opts.isChangeDataCapture) {
+      this._topic = '/data/' + opts.topic;
+  } else {
     this._topic = '/topic/' + opts.topic;
   }
 


### PR DESCRIPTION
[Change Data Capture events](https://trailhead.salesforce.com/content/learn/modules/change-data-capture/learn-change-data-capture-characteristics) are similar to Platform Events and Push Topics, except for the url of `/data/*` instead of `/topic/*` or `/event/*`. I'd love to be able to stream Change Data Capture events using nforce.